### PR TITLE
Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse/components/b-editor-html-lean.js.es6
+++ b/assets/javascripts/discourse/components/b-editor-html-lean.js.es6
@@ -3,7 +3,6 @@ import { getOwner } from 'discourse-common/lib/get-owner';
 import { cookAsync } from "discourse/lib/text";
 import { ajax } from "discourse/lib/ajax";
 import discourseComputed, {  observes,  on } from "discourse-common/utils/decorators";
-import { debounce, later, next, schedule, scheduleOnce } from "@ember/runloop";
 import ENV from "discourse-common/config/environment";
 export default Ember.Component.extend({
   classNames: ["d-editor"],

--- a/assets/javascripts/discourse/components/b-editor.js.es6
+++ b/assets/javascripts/discourse/components/b-editor.js.es6
@@ -3,8 +3,10 @@ import { getOwner } from 'discourse-common/lib/get-owner';
 import { cookAsync } from "discourse/lib/text";
 import { ajax } from "discourse/lib/ajax";
 import getURL from "discourse-common/lib/get-url";
-import { debounce, later, next, schedule, scheduleOnce } from "@ember/runloop";
+import { schedule } from "@ember/runloop";
+import debounce from "discourse/plugins/discourse-basic-editor/lib/debounce";
 import ENV from "discourse-common/config/environment";
+
 export default Ember.Component.extend({
   classNames: ["d-editor"],
   _updatePreview() {

--- a/assets/javascripts/initializers/discourse-basic-editor.js.es6
+++ b/assets/javascripts/initializers/discourse-basic-editor.js.es6
@@ -4,7 +4,7 @@ import loadScript from "discourse/lib/load-script";
 import discourseComputed, {  observes,  on } from "discourse-common/utils/decorators";
 import ComposerEditor from "discourse/components/composer-editor";
 import putCursorAtEnd from "discourse/lib/put-cursor-at-end";
-import { debounce, later, next, schedule, throttle } from "@ember/runloop";
+import { schedule, throttle } from "@ember/runloop";
 import { findRawTemplate } from "discourse/lib/raw-templates";
 import { onToolbarCreate } from 'discourse/components/d-editor';
 import { getOwner } from 'discourse-common/lib/get-owner';

--- a/assets/javascripts/lib/debounce.js.es6
+++ b/assets/javascripts/lib/debounce.js.es6
@@ -1,0 +1,6 @@
+import discourseDebounce from "discourse-common/lib/debounce";
+import { debounce } from "@ember/runloop";
+
+// TODO: Remove this file and use discouseDebounce after the 2.7 release.
+const debounceFunction = discourseDebounce || debounce;
+export default debounceFunction;


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.